### PR TITLE
Fixed a bug. Loss of selection when rotating the screen.

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/libra/fragment/IssuesFragment.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/libra/fragment/IssuesFragment.kt
@@ -108,13 +108,7 @@ class IssuesFragment : Fragment() {
 		}
 		listView.setOnItemLongClickListener { _, v, position, id ->
 			v.isSelected = true
-			adapter.select(id, position)
-			val a = activity
-			if (actionMode == null && a is AppCompatActivity) {
-				actionMode = a.delegate.startSupportActionMode(
-					actionModeCallback
-				)
-			}
+			editIssue(id,position)
 			true
 		}
 
@@ -122,8 +116,30 @@ class IssuesFragment : Fragment() {
 		addButton.setOnClickListener {
 			showArguments(db.insertIssue())
 		}
+		if (state != null) {
+			val id = state.getLong(ISSUES_ID, 0)
+			val position = state.getInt(POSITION_ID,0)
+			if (id > 0) {
+				editIssue(id, position)
+			}
+		}
 
 		return view
+	}
+
+	private fun editIssue(id: Long, position: Int) {
+		adapter.select(id, position)
+		val a = activity
+		if (actionMode == null && a is AppCompatActivity) {
+			actionMode = a.delegate.startSupportActionMode(
+				actionModeCallback
+			)
+		}
+	}
+
+	override fun onSaveInstanceState(outState: Bundle) {
+		outState.putLong(ISSUES_ID, adapter.selectedId)
+		outState.putInt(POSITION_ID, adapter.selectedPosition)
 	}
 
 	override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -159,6 +175,11 @@ class IssuesFragment : Fragment() {
 
 	private fun updateList() {
 		adapter.changeCursor(db.getIssues())
+	}
+
+	companion object{
+		private const val ISSUES_ID = "issuesID"
+		private const val POSITION_ID = "positionID"
 	}
 }
 


### PR DESCRIPTION
When selecting an issue in IssuesFragment, and rotating the screen, it would deselect. But that didn't happen with ArgumentsFragment. I recreated your solution from ArgumentsFragment to IssuesFragment, and now the bug is fixed. When rotating the screen, it is still selected.